### PR TITLE
Sample GitHub Action for Automated Builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Build project
 
-on: [pull_request]
+on:
+    push:
+        branches:
+            - main
 
 jobs:
   buildForAllSupportedPlatforms:


### PR DESCRIPTION
In theory this should do the following:

Upon a push to _main_, the action will be invoked. This will spin up a Linux VM, which will:
1. Check out the repo so that the VM has access to the files to build.
2. Use GameCI's builder to start a build.
3. Create a link to the completed build if successful on the actions page. 

No way to test this without merging this PR to staging, followed by merging staging to main. I suggest we test this after faculty playthroughs or after any other PRs have been merged. This should not directly touch the project.