### PR TITLE
Fixed the early door activation glitch in the intermission scene

### DIFF
--- a/Assets/Scenes/TestIntermissions/IN_Prototype.unity
+++ b/Assets/Scenes/TestIntermissions/IN_Prototype.unity
@@ -3018,7 +3018,7 @@ BoxCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 3
   m_Size: {x: 2, y: 2, z: 6}
   m_Center: {x: 0, y: 0, z: 0}
@@ -3039,7 +3039,7 @@ BoxCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 3
   m_Size: {x: 6, y: 2, z: 2}
   m_Center: {x: 0, y: 0, z: 0}
@@ -6161,8 +6161,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 1, z: 2.9091516}
+  m_Center: {x: 0, y: 0, z: -0.9545758}
 --- !u!1001 &2032505963
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
[Link to external documentation](https://docs.google.com/document/d/1Z44ujiMOaL0XbOeM_I7_fslkydXpmUhHHlha32JHxgw/edit?usp=sharing) 

Disabled the extra box colliders attached to the player in the IN_Prototype scene, fixing the early door activation bug.

I did not write any code, therefore I only have external documentation.