### PR TITLE
Debug menu manager cleanup

### DIFF
--- a/Assets/Scripts/Build Tools/DebugMenuManager.cs
+++ b/Assets/Scripts/Build Tools/DebugMenuManager.cs
@@ -23,7 +23,7 @@ public class DebugMenuManager : MonoBehaviour
 
     public bool GhostMode { get; private set; } = false;
     public bool Invincibility { get; private set; } = false;
-    public bool PauseMenu { get; private set; } = false;
+    public bool PauseMenu { get; set; } = false;
 
     [SerializeField] private GameObject _debugMenuFirst;
     [SerializeField] private GameObject _quitMenuFirst;


### PR DESCRIPTION
Cleans up the DebugMenuManger script to line up with [Malcom's Code Standard Adherence.](https://docs.google.com/spreadsheets/d/1Mx-1GcCARRrjvOJyw3WPuIbVP6JsmS2iLJg5nxwigc4/edit?usp=sharing)
Violated rules that I fixed were at General Code Guidelines: Public Variables, Code Maintainability: Naming, Nomenclature: Fields, Nomenclature: Misc, Brace Style: Spacing.
