### PR TITLE
Fix Circle Wipe Reset

### DIFF
--- a/Assets/Scripts/SceneController.cs
+++ b/Assets/Scripts/SceneController.cs
@@ -68,6 +68,8 @@ public class SceneController : MonoBehaviour
     /// </summary>
     public void ReloadCurrentScene()
     {
+        if (Transitioning) { return; }
+
         StopAllCoroutines();
         _currentFadeColor = Color.black;
         int sceneIndex = SceneManager.GetActiveScene().buildIndex;
@@ -80,6 +82,8 @@ public class SceneController : MonoBehaviour
     /// <param name="sceneBuildIndex">Build index of the scene to load</param>
     public void LoadNewScene(int sceneBuildIndex)
     {
+        if (Transitioning) { return; }
+
         StopAllCoroutines();
         _currentFadeColor = Color.white;
         StartCoroutine(CircleWipeTransition(false, _currentFadeColor, sceneBuildIndex));


### PR DESCRIPTION
Added a guard clause to the scene controller to prevent the circle wipe from resetting itself mid-activation.