### PR TITLE
Fixed Illness Enemy Null Ref

### DIFF
--- a/Assets/Prefabs/Entities/Enemy.prefab
+++ b/Assets/Prefabs/Entities/Enemy.prefab
@@ -3926,6 +3926,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _destinationMarker: {fileID: 2474659038540386944}
   _destPathVFX: {fileID: 4121013918361156318}
+  _destPathMarkerPrefab: {fileID: 2474659038540386944}
   _destYPos: 0.2
   _lineYPosOffset: 1
   _timeBeforeTurn: 0.1


### PR DESCRIPTION
The ouchie square vfx prefab reference was not set for the illness enemy making the game softlock if you try to move in a scene with one.