### PR TITLE
Fixed Misinput Bug

### DIFF
--- a/Assets/Scripts/RoundManager.cs
+++ b/Assets/Scripts/RoundManager.cs
@@ -204,8 +204,6 @@ public sealed class RoundManager : MonoBehaviour
         {
             return;
         }
-        if (Time.timeScale > 1)
-            return;
 
         var dir = GetNormalizedInput();
 
@@ -227,7 +225,10 @@ public sealed class RoundManager : MonoBehaviour
 
         _movementRegistered = true;
         _movementRegisteredTime = Time.unscaledTime;
-        
+
+        if (Time.timeScale > 1)
+            return;
+
         PerformMovement();
     }
 


### PR DESCRIPTION
Fixed a bug that would input a movement even if the player changed their direction before their turn started while moving during Sprint/Autocomplete.

Should be tested in levels both with and without enemies, while holding down Sprint/Autocomplete.
Test levels used: FourNotes and FoeSplit